### PR TITLE
Add fallback chase action when policy logits are uniform

### DIFF
--- a/AgentIndex.lua
+++ b/AgentIndex.lua
@@ -1,4 +1,5 @@
 local CollectionService = game:GetService("CollectionService")
+local Players = game:GetService("Players")
 
 local M = {}
 
@@ -11,6 +12,15 @@ local function validBot(model)
 	local hum = model:FindFirstChildOfClass("Humanoid")
 	local root = getRoot(model)
 	return hum ~= nil and root ~= nil and CollectionService:HasTag(model, "AIBot")
+end
+
+local function validTarget(model)
+	if not model or not model.Parent then return false end
+	local hum = model:FindFirstChildOfClass("Humanoid")
+	local root = getRoot(model)
+	if hum == nil or root == nil then return false end
+	if CollectionService:HasTag(model, "AIBot") then return false end
+	return true
 end
 
 function M.listAgents()
@@ -38,16 +48,50 @@ function M.listAgents()
 	return out
 end
 
--- NEW: only return the nearest **other bot**
+-- Return the nearest other bot for combat
 function M.pickEnemy(agent)
 	local aPos = agent.root.Position
 	local best, bestd
-	for _,other in ipairs(M.listAgents()) do
+	for _, other in ipairs(M.listAgents()) do
 		if other.model ~= agent.model then
 			local d = (other.root.Position - aPos).Magnitude
-			if not bestd or d < bestd then best, bestd = other.model, d end
+			if not bestd or d < bestd then
+				best, bestd = other.model, d
+			end
 		end
 	end
+	return best, bestd or math.huge
+end
+
+-- Fall back to chasing the closest valid player or NPC target
+function M.pickTarget(agent)
+	if not agent or not agent.root then return nil, math.huge end
+
+	local origin = agent.root.Position
+	local best, bestd
+	local seen = {}
+
+	local function consider(model)
+		if not model or seen[model] then return end
+		seen[model] = true
+		if not validTarget(model) then return end
+		local root = getRoot(model)
+		local d = (root.Position - origin).Magnitude
+		if not bestd or d < bestd then
+			best, bestd = model, d
+		end
+	end
+
+	for _, player in ipairs(Players:GetPlayers()) do
+		consider(player.Character)
+	end
+
+	for _, child in ipairs(workspace:GetChildren()) do
+		if typeof(child) == "Instance" and child:IsA("Model") and child ~= agent.model then
+			consider(child)
+		end
+	end
+
 	return best, bestd or math.huge
 end
 

--- a/PolicyActor.lua
+++ b/PolicyActor.lua
@@ -7,6 +7,7 @@ local FeatureEncoder = require(pkg:WaitForChild("FeatureEncoder"))
 
 local M = {}
 local _policy
+local _fallbackCtr = {}
 
 local function relu(v)
 	for i=1,#v do v[i] = (v[i] or 0) > 0 and v[i] or 0 end
@@ -24,19 +25,53 @@ local function matvec(weight, bias, x)
 end
 
 local function argmax(t)
-	local k, best = 1, -math.huge
-	for i=1,#t do
-		local v = t[i] or -math.huge
-		if v > best then best, k = v, i end
-	end
-	return k
+        local k, best = 1, -math.huge
+        for i=1,#t do
+                local v = t[i] or -math.huge
+                if v > best then best, k = v, i end
+        end
+        return k
+end
+
+local function allEqual(t)
+        if #t <= 1 then return true end
+        local first = t[1]
+        for i = 2, #t do
+                if t[i] ~= first then return false end
+        end
+        return true
+end
+
+local function fallbackAction(agent)
+        local actions = ActionMapper.actions() or {}
+        if #actions == 0 then return 1, "Idle" end
+
+        -- Prefer an explicit "Chase" action so bots move by default.
+        local chaseIdx
+        for i, name in ipairs(actions) do
+                if name == "Chase" then
+                        chaseIdx = i
+                        break
+                end
+        end
+
+        if chaseIdx then
+                return chaseIdx, actions[chaseIdx]
+        end
+
+        -- Otherwise cycle through the available actions per-agent.
+        local agentKey = agent and (agent.id or agent)
+        local n = math.max(1, #actions)
+        _fallbackCtr[agentKey] = ((_fallbackCtr[agentKey] or 0) % n) + 1
+        local idx = _fallbackCtr[agentKey]
+        return idx, actions[idx] or "Idle"
 end
 
 local function getFeatures(agent, want)
-	-- Prefer FeatureEncoder.encode(agent, want) if present; else zeros.
-	if type(FeatureEncoder.encode) == "function" then
-		local ok, feat = pcall(FeatureEncoder.encode, agent, want)
-		if ok and type(feat) == "table" and #feat == want then return feat end
+        -- Prefer FeatureEncoder.encode(agent, want) if present; else zeros.
+        if type(FeatureEncoder.encode) == "function" then
+                local ok, feat = pcall(FeatureEncoder.encode, agent, want)
+                if ok and type(feat) == "table" and #feat == want then return feat end
 	end
 	local z = table.create(want, 0)
 	return z
@@ -54,12 +89,15 @@ end
 
 -- Accepts the full agent table (id/model/humanoid/root)
 function M.nextAction(agent)
-	_policy = _policy or PolicyLoader.load()
-	local feat = getFeatures(agent, _policy.feature_dim)
-	local logits = forward(feat)
-	local idx = argmax(logits)
-	local name = (ActionMapper.actions() or {})[idx]
-	return idx, name
+        _policy = _policy or PolicyLoader.load()
+        local feat = getFeatures(agent, _policy.feature_dim)
+        local logits = forward(feat)
+        if #logits == 0 or allEqual(logits) then
+                return fallbackAction(agent)
+        end
+        local idx = argmax(logits)
+        local name = (ActionMapper.actions() or {})[idx]
+        return idx, name
 end
 
 return M


### PR DESCRIPTION
## Summary
- add a fallback behaviour in `PolicyActor.nextAction` so bots choose a chase action when the policy outputs uniform logits
- cycle through available actions per-agent if no chase action is defined, ensuring movement-oriented defaults instead of idling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0a8578eec832fa7d21b247342ac6c